### PR TITLE
feat(nginx): configurar domínio e letsencrypt para globoclima.dedyn.io

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,8 +142,11 @@ jobs:
           # Limpar imagens não utilizadas
           sudo docker image prune -f
           
-          # Mostrar IP para acesso
-          EC2_IP=$(curl -s ifconfig.me)
-          echo "Deploy com HTTPS (certificado auto-assinado) concluído!"
-          echo "Acesse: https://${EC2_IP} (aceite o aviso de segurança)"
-          echo "Swagger: https://${EC2_IP}/swagger"
+          # Mostrar informações de acesso
+          echo "Deploy com HTTPS concluído!"
+          echo "Domínio configurado: globoclima.dedyn.io"
+          echo "Acesse: https://globoclima.dedyn.io"
+          echo "Swagger: https://globoclima.dedyn.io/swagger"
+          echo ""
+          echo "NOTA: Certifique-se de que o DNS do domínio aponta para este servidor"
+          echo "IP do servidor: $(curl -s ifconfig.me)"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,17 +10,17 @@ http {
     # Redirect HTTP to HTTPS
     server {
         listen 80;
-        server_name _;
+        server_name globoclima.dedyn.io;
         
         location / {
             return 301 https://$server_name$request_uri;
         }
     }
 
-    # HTTPS Server with self-signed certificate
+    # HTTPS Server with domain certificate
     server {
         listen 443 ssl http2;
-        server_name _;
+        server_name globoclima.dedyn.io;
 
         ssl_certificate /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;

--- a/scripts/generate-ssl.sh
+++ b/scripts/generate-ssl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-echo "Gerando certificado SSL auto-assinado..."
+echo "Gerando certificado SSL para globoclima.dedyn.io..."
 
 # Criar diretório para certificados
 mkdir -p ssl
@@ -9,10 +9,13 @@ mkdir -p ssl
 # Gerar chave privada
 openssl genrsa -out ssl/server.key 2048
 
-# Gerar certificado auto-assinado (válido por 365 dias)
-openssl req -new -x509 -key ssl/server.key -out ssl/server.crt -days 365 -subj "/C=BR/ST=State/L=City/O=Organization/CN=localhost"
+# Gerar certificado auto-assinado para o domínio (válido por 365 dias)
+openssl req -new -x509 -key ssl/server.key -out ssl/server.crt -days 365 -subj "/C=BR/ST=State/L=City/O=GloboClima/CN=globoclima.dedyn.io"
 
-echo "Certificado SSL gerado com sucesso!"
+echo "Certificado SSL gerado com sucesso para globoclima.dedyn.io!"
 echo "Arquivos criados:"
 echo "- ssl/server.key (chave privada)"
 echo "- ssl/server.crt (certificado)"
+echo ""
+echo "IMPORTANTE: Para produção, considere usar Let's Encrypt:"
+echo "sudo certbot --nginx -d globoclima.dedyn.io"

--- a/scripts/setup-letsencrypt.sh
+++ b/scripts/setup-letsencrypt.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+echo "Configurando Let's Encrypt para globoclima.dedyn.io..."
+
+# Instalar certbot se não estiver instalado
+sudo apt update
+sudo apt install -y certbot python3-certbot-nginx
+
+# Parar nginx temporariamente
+sudo docker-compose stop nginx
+
+# Gerar certificado Let's Encrypt
+sudo certbot certonly --standalone -d globoclima.dedyn.io --email seu-email@exemplo.com --agree-tos --non-interactive
+
+# Copiar certificados para o diretório ssl
+sudo cp /etc/letsencrypt/live/globoclima.dedyn.io/fullchain.pem ssl/server.crt
+sudo cp /etc/letsencrypt/live/globoclima.dedyn.io/privkey.pem ssl/server.key
+sudo chown $USER:$USER ssl/server.*
+
+# Reiniciar nginx
+sudo docker-compose start nginx
+
+echo "Certificado Let's Encrypt configurado com sucesso!"
+echo "Lembre-se de configurar renovação automática com: sudo crontab -e"
+echo "Adicione: 0 12 * * * /usr/bin/certbot renew --quiet"


### PR DESCRIPTION
- Atualizar a configuração do nginx para usar o nome de domínio em vez do curinga
- Adicionar script para configurar os certificados Let's Encrypt
- Atualizar o fluxo de trabalho de implantação para refletir o uso do domínio
- Modificar o script de geração de SSL para incluir informações do domínio