### PR TITLE
feat(auth): implementar autenticação JWT com backend DynamoDB

### DIFF
--- a/GloboClima/Controllers/AuthController.cs
+++ b/GloboClima/Controllers/AuthController.cs
@@ -1,0 +1,85 @@
+using Microsoft.AspNetCore.Mvc;
+using GloboClima.Models;
+using GloboClima.Services;
+
+namespace GloboClima.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService _authService;
+    private readonly ILogger<AuthController> _logger;
+
+    public AuthController(IAuthService authService, ILogger<AuthController> logger)
+    {
+        _authService = authService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Realiza login do usuário
+    /// </summary>
+    /// <param name="request">Dados de login</param>
+    /// <returns>Token JWT se login for bem-sucedido</returns>
+    [HttpPost("login")]
+    [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(LoginResponse))]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request)
+    {
+        try
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var result = await _authService.LoginAsync(request);
+            if (result == null)
+            {
+                return Unauthorized(new { message = "Credenciais inválidas" });
+            }
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao fazer login");
+            return StatusCode(500, new { message = "Erro interno do servidor" });
+        }
+    }
+
+    /// <summary>
+    /// Registra um novo usuário
+    /// </summary>
+    /// <param name="request">Dados de cadastro</param>
+    /// <returns>Sucesso ou erro no cadastro</returns>
+    [HttpPost("register")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Register([FromBody] RegisterRequest request)
+    {
+        try
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            var success = await _authService.RegisterAsync(request);
+            if (!success)
+            {
+                return Conflict(new { message = "Usuário já existe" });
+            }
+
+            return Created("", new { message = "Usuário criado com sucesso" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao registrar usuário");
+            return StatusCode(500, new { message = "Erro interno do servidor" });
+        }
+    }
+}

--- a/GloboClima/GloboClima.csproj
+++ b/GloboClima/GloboClima.csproj
@@ -18,6 +18,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.0.3" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.300" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.7" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
   </ItemGroup>
 
 </Project>

--- a/GloboClima/Models/LoginRequest.cs
+++ b/GloboClima/Models/LoginRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GloboClima.Models;
+
+public class LoginRequest
+{
+    [Required(ErrorMessage = "Username é obrigatório")]
+    public string Username { get; set; } = string.Empty;
+    
+    [Required(ErrorMessage = "Password é obrigatório")]
+    public string Password { get; set; } = string.Empty;
+}

--- a/GloboClima/Models/LoginResponse.cs
+++ b/GloboClima/Models/LoginResponse.cs
@@ -1,0 +1,8 @@
+namespace GloboClima.Models;
+
+public class LoginResponse
+{
+    public string Token { get; set; } = string.Empty;
+    public string Username { get; set; } = string.Empty;
+    public DateTime ExpiresAt { get; set; }
+}

--- a/GloboClima/Models/RegisterRequest.cs
+++ b/GloboClima/Models/RegisterRequest.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GloboClima.Models;
+
+public class RegisterRequest
+{
+    [Required(ErrorMessage = "Username é obrigatório")]
+    [MinLength(3, ErrorMessage = "Username deve ter pelo menos 3 caracteres")]
+    public string Username { get; set; } = string.Empty;
+    
+    [Required(ErrorMessage = "Password é obrigatório")]
+    [MinLength(6, ErrorMessage = "Password deve ter pelo menos 6 caracteres")]
+    public string Password { get; set; } = string.Empty;
+}

--- a/GloboClima/Models/User.cs
+++ b/GloboClima/Models/User.cs
@@ -1,0 +1,25 @@
+using Amazon.DynamoDBv2.DataModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace GloboClima.Models;
+
+[DynamoDBTable("Users")]
+public class User
+{
+    [DynamoDBHashKey]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    
+    [DynamoDBProperty]
+    [Required]
+    public string Username { get; set; } = string.Empty;
+    
+    [DynamoDBProperty]
+    [Required]
+    public string PasswordHash { get; set; } = string.Empty;
+    
+    [DynamoDBProperty]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    
+    [DynamoDBProperty]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/GloboClima/Program.cs
+++ b/GloboClima/Program.cs
@@ -1,4 +1,9 @@
+using Amazon.DynamoDBv2;
+using Amazon.DynamoDBv2.DataModel;
 using GloboClima.Services;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -9,14 +14,58 @@ if (string.IsNullOrEmpty(builder.Configuration["APIKEY"]))
     builder.Configuration["APIKEY"] = Environment.GetEnvironmentVariable("WEATHER_API_KEY") ?? "";
 }
 
+var dynamoDbConfig = new AmazonDynamoDBConfig();
+var dynamoDbEndpoint = builder.Configuration["DYNAMODB_ENDPOINT"];
+
+if (!string.IsNullOrEmpty(dynamoDbEndpoint))
+{
+    dynamoDbConfig.ServiceURL = dynamoDbEndpoint;
+    dynamoDbConfig.UseHttp = true;
+    
+    builder.Services.AddSingleton<IAmazonDynamoDB>(provider =>
+    {
+        return new AmazonDynamoDBClient("dummy", "dummy", dynamoDbConfig);
+    });
+}
+else
+{
+    builder.Services.AddSingleton<IAmazonDynamoDB>(new AmazonDynamoDBClient(dynamoDbConfig));
+}
+
+builder.Services.AddSingleton<IDynamoDBContext>(provider =>
+{
+    var client = provider.GetService<IAmazonDynamoDB>();
+    return new DynamoDBContext(client);
+});
+
+var jwtSecret = builder.Configuration["JWT_SECRET"] ?? "chave-de-api-se-env-vazio";
+var key = Encoding.ASCII.GetBytes(jwtSecret);
+
+builder.Services.AddAuthentication(x =>
+{
+    x.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    x.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+})
+.AddJwtBearer(x =>
+{
+    x.RequireHttpsMetadata = false;
+    x.SaveToken = true;
+    x.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(key),
+        ValidateIssuer = false,
+        ValidateAudience = false
+    };
+});
+
 builder.Services.AddControllers();
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
 builder.Services.AddHealthChecks();
 
 builder.Services.AddHttpClient<ICountryService, CountryService>();
+builder.Services.AddScoped<IAuthService, AuthService>();
 
 var app = builder.Build();
 
@@ -36,9 +85,49 @@ app.UseCors(policy =>
 app.MapHealthChecks("/health");
 
 app.UseHttpsRedirection();
-
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+
+using (var scope = app.Services.CreateScope())
+{
+    var dynamoDbContext = scope.ServiceProvider.GetRequiredService<IDynamoDBContext>();
+    var client = scope.ServiceProvider.GetRequiredService<IAmazonDynamoDB>();
+    
+    try
+    {
+        var tableNames = await client.ListTablesAsync();
+        if (!tableNames.TableNames.Contains("Users"))
+        {
+            await client.CreateTableAsync(new Amazon.DynamoDBv2.Model.CreateTableRequest
+            {
+                TableName = "Users",
+                KeySchema = new List<Amazon.DynamoDBv2.Model.KeySchemaElement>
+                {
+                    new Amazon.DynamoDBv2.Model.KeySchemaElement
+                    {
+                        AttributeName = "Id",
+                        KeyType = Amazon.DynamoDBv2.KeyType.HASH
+                    }
+                },
+                AttributeDefinitions = new List<Amazon.DynamoDBv2.Model.AttributeDefinition>
+                {
+                    new Amazon.DynamoDBv2.Model.AttributeDefinition
+                    {
+                        AttributeName = "Id",
+                        AttributeType = Amazon.DynamoDBv2.ScalarAttributeType.S
+                    }
+                },
+                BillingMode = Amazon.DynamoDBv2.BillingMode.PAY_PER_REQUEST
+            });
+        }
+    }
+    catch (Exception ex)
+    {
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+        logger.LogWarning(ex, "Não foi possível criar/verificar a tabela Users no DynamoDB");
+    }
+}
 
 app.Run();

--- a/GloboClima/Services/AuthService.cs
+++ b/GloboClima/Services/AuthService.cs
@@ -1,0 +1,120 @@
+using Amazon.DynamoDBv2.DataModel;
+using Amazon.DynamoDBv2.DocumentModel;
+using GloboClima.Models;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace GloboClima.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly IDynamoDBContext _dynamoDbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<AuthService> _logger;
+
+    public AuthService(IDynamoDBContext dynamoDbContext, IConfiguration configuration, ILogger<AuthService> logger)
+    {
+        _dynamoDbContext = dynamoDbContext;
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public async Task<LoginResponse?> LoginAsync(LoginRequest request)
+    {
+        try
+        {
+            var user = await GetUserByUsernameAsync(request.Username);
+            if (user == null || !BCrypt.Net.BCrypt.Verify(request.Password, user.PasswordHash))
+            {
+                return null;
+            }
+
+            var token = GenerateJwtToken(user);
+            return new LoginResponse
+            {
+                Token = token,
+                Username = user.Username,
+                ExpiresAt = DateTime.UtcNow.AddHours(24)
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao fazer login para o usuário {Username}", request.Username);
+            throw;
+        }
+    }
+
+    public async Task<bool> RegisterAsync(RegisterRequest request)
+    {
+        try
+        {
+            if (await UserExistsAsync(request.Username))
+            {
+                return false;
+            }
+
+            var user = new User
+            {
+                Username = request.Username,
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(request.Password)
+            };
+
+            await _dynamoDbContext.SaveAsync(user);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao registrar usuário {Username}", request.Username);
+            throw;
+        }
+    }
+
+    public async Task<bool> UserExistsAsync(string username)
+    {
+        try
+        {
+            var user = await GetUserByUsernameAsync(username);
+            return user != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Erro ao verificar se usuário {Username} existe", username);
+            throw;
+        }
+    }
+
+    public string GenerateJwtToken(User user)
+    {
+        var jwtSecret = _configuration["JWT_SECRET"] ?? "your-super-secret-jwt-key-here-make-it-long-and-secure";
+        var key = Encoding.ASCII.GetBytes(jwtSecret);
+        
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, user.Id),
+                new Claim(ClaimTypes.Name, user.Username)
+            }),
+            Expires = DateTime.UtcNow.AddHours(24),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+        
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    private async Task<User?> GetUserByUsernameAsync(string username)
+    {
+        var scanConditions = new List<ScanCondition>
+        {
+            new ScanCondition("Username", ScanOperator.Equal, username)
+        };
+        
+        var search = _dynamoDbContext.ScanAsync<User>(scanConditions);
+        var users = await search.GetNextSetAsync();
+        return users.FirstOrDefault();
+    }
+}

--- a/GloboClima/Services/IAuthService.cs
+++ b/GloboClima/Services/IAuthService.cs
@@ -1,0 +1,30 @@
+using GloboClima.Models;
+
+namespace GloboClima.Services;
+
+public interface IAuthService
+{
+    /// <summary>
+    /// Realiza o login do usuário.
+    /// </summary>
+    /// <param name="request">Dados de login do usuário.</param>
+    /// <returns>Resposta de login contendo o token JWT e informações do usuário.</returns>
+    /// <exception cref="Exception">Lançada quando ocorre um erro inesperado.</exception>
+    Task<LoginResponse?> LoginAsync(LoginRequest request);
+    
+    /// <summary>
+    /// Registra um novo usuário.
+    /// </summary>
+    /// <param name="request">Dados de registro do usuário.</param>
+    /// <returns>True se o registro for bem-sucedido, false caso contrário.</returns>
+    /// <exception cref="Exception">Lançada quando ocorre um erro inesperado.</exception>
+    Task<bool> RegisterAsync(RegisterRequest request);
+    
+    /// <summary>
+    /// Verifica se um usuário existe.
+    /// </summary>
+    /// <param name="username">Nome de usuário a ser verificado.</param>
+    /// <returns>True se o usuário existir, false caso contrário.</returns>
+    /// <exception cref="Exception">Lançada quando ocorre um erro inesperado.</exception>
+    Task<bool> UserExistsAsync(string username);
+}

--- a/GloboClima/appsettings.Development.json
+++ b/GloboClima/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  }
+  },
+  "AWS": {
+    "Profile": "default",
+    "Region": "us-east-1"
+  },
+  "DYNAMODB_ENDPOINT": "http://localhost:8000",
+  "JWT_SECRET": "chave-de-api-se-env-vazio"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,25 @@ services:
       - ASPNETCORE_ENVIRONMENT=Production
       - ASPNETCORE_URLS=http://+:8080
       - WEATHER_API_KEY=${WEATHER_API_KEY}
+      - AWS_ACCESS_KEY_ID=dummy
+      - AWS_SECRET_ACCESS_KEY=dummy
+      - AWS_DEFAULT_REGION=us-east-1
+      - DYNAMODB_ENDPOINT=http://dynamodb-local:8000
+      - JWT_SECRET=${JWT_SECRET:-your-super-secret-jwt-key-here-make-it-long-and-secure}
+    depends_on:
+      - dynamodb-local
+    networks:
+      - globoclima-network
+
+  dynamodb-local:
+    image: amazon/dynamodb-local:latest
+    container_name: globoclima-dynamodb
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    command: ["-jar", "DynamoDBLocal.jar", "-sharedDb", "-dbPath", "./data"]
+    volumes:
+      - dynamodb_data:/home/dynamodblocal/data
     networks:
       - globoclima-network
 
@@ -28,6 +47,9 @@ services:
       - globoclima-app
     networks:
       - globoclima-network
+
+volumes:
+  dynamodb_data:
 
 networks:
   globoclima-network:


### PR DESCRIPTION
- Adicionar AuthController com end-points de login e registro
- Criar AuthService com geração de token JWT e gerenciamento de usuários
- Adicionar modelos User, LoginRequest, LoginResponse e RegisterRequest
- Configurar DynamoDB local para desenvolvimento e autenticação JWT
- Atualizar docker-compose para incluir o serviço DynamoDB
- Adicionar pacotes NuGet necessários para autenticação e DynamoDB